### PR TITLE
[BE] feat - #68 : User Service 2차 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-server/src/test/
+.idea

--- a/server/src/main/java/jeju/oneroom/message/dto/MessageDto.java
+++ b/server/src/main/java/jeju/oneroom/message/dto/MessageDto.java
@@ -28,7 +28,7 @@ public class MessageDto {
         private Long id; // messageId
         private String content; // 내용
         private LocalDateTime createdAt; // 보낸시간
-        private UserDto.SimpleResponseDto user;
+        private UserDto.SimpleResponse user;
     }
 }
 

--- a/server/src/main/java/jeju/oneroom/post/dto/PostDto.java
+++ b/server/src/main/java/jeju/oneroom/post/dto/PostDto.java
@@ -34,7 +34,7 @@ public class PostDto {
     @NoArgsConstructor
     public static class Response {
         private Long id; // postId
-        private UserDto.SimpleResponseDto writer;
+        private UserDto.SimpleResponse writer;
         private String title; // 제목
         private String content; // 내용
         private String houseAddress;

--- a/server/src/main/java/jeju/oneroom/postComment/dto/PostCommentDto.java
+++ b/server/src/main/java/jeju/oneroom/postComment/dto/PostCommentDto.java
@@ -32,6 +32,6 @@ public class PostCommentDto {
         private String content; // 내용
         private LocalDateTime createdAt; // 작성 날짜
         private LocalDateTime modifiedAt; // 수정날짜
-        private UserDto.SimpleResponseDto writer; // 작성자 정보
+        private UserDto.SimpleResponse writer; // 작성자 정보
     }
 }

--- a/server/src/main/java/jeju/oneroom/review/controller/ReviewController.java
+++ b/server/src/main/java/jeju/oneroom/review/controller/ReviewController.java
@@ -33,7 +33,7 @@ public class ReviewController {
     public ResponseEntity<?> post(@Valid @RequestBody ReviewDto.Post postDto,
                                   @RequestParam long userId) {
         HouseInfo houseInfo = houseInfoService.findVerifiedHouseInfoByAddress(postDto.getAddress());
-        User user = userService.findVerifiedUser(userId);
+        User user = userService.verifyExistsUser(userId);
         Review review = reviewService.createReview(postDto, houseInfo, user);
         return new ResponseEntity<>(review.getId(), HttpStatus.CREATED);
     }
@@ -68,7 +68,7 @@ public class ReviewController {
     // 유저 관심 지역 추천 순 리뷰 5개
     @GetMapping("users/{user-id}/user-areas/reviews")
     public ResponseEntity<?> getTop5UserAreaReviews(@PathVariable("user-id") long userId) {
-        User user = userService.findVerifiedUser(userId);
+        User user = userService.verifyExistsUser(userId);
         List<ReviewDto.SimpleResponse> userAreaReviews = reviewService.findTop5UserAreaReviews(user);
         return new ResponseEntity<>(new ListResponseDto<>(userAreaReviews), HttpStatus.OK);
     }
@@ -78,7 +78,7 @@ public class ReviewController {
     public ResponseEntity<?> getUserReviews(@RequestParam int page,
                                             @RequestParam int size,
                                             @PathVariable("user-id") long userId) {
-        User user = userService.findVerifiedUser(userId);
+        User user = userService.verifyExistsUser(userId);
         Page<ReviewDto.SimpleResponse> userReviews = reviewService.findUserReviews(user, page, size);
         return new ResponseEntity<>(new MultiResponseDto<>(userReviews), HttpStatus.OK);
     }

--- a/server/src/main/java/jeju/oneroom/review/dto/ReviewDto.java
+++ b/server/src/main/java/jeju/oneroom/review/dto/ReviewDto.java
@@ -65,7 +65,7 @@ public class ReviewDto {
         private LocalDateTime modifiedAt;
 
         // 작성자 정보는 머지 후 추가
-        private UserDto.SimpleResponseDto writer;
+        private UserDto.SimpleResponse writer;
     }
 
     // 특정 동의 추천 순 리뷰 30개

--- a/server/src/main/java/jeju/oneroom/user/controller/UserController.java
+++ b/server/src/main/java/jeju/oneroom/user/controller/UserController.java
@@ -1,45 +1,53 @@
 package jeju.oneroom.user.controller;
 
+import jeju.oneroom.area.entity.Area;
+import jeju.oneroom.area.service.AreaService;
 import jeju.oneroom.user.dto.UserDto;
+import jeju.oneroom.user.entity.User;
 import jeju.oneroom.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
 
+@Slf4j
+@Validated
 @RestController
 @RequestMapping("/users")
 @RequiredArgsConstructor
-@Slf4j
 public class UserController {
 
     private final UserService userService;
+    private final AreaService areaService;
 
-    //회원 생성
     @PostMapping
-    public ResponseEntity<?> post(@Valid @RequestBody UserDto.Post postDto) {
-        UserDto.Response response = userService.createUser(postDto);
-        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    public ResponseEntity<Long> post(@Valid @RequestBody UserDto.Post postDto) {
+        User user = userService.createUser(postDto);
+        return new ResponseEntity<>(user.getId(), HttpStatus.CREATED);
     }
 
     @PatchMapping("/{user-id}")
-    public ResponseEntity<?> patch(@Valid @RequestBody UserDto.Patch patchDto) {
-        UserDto.Response response = userService.updateUser(patchDto);
-        return new ResponseEntity<>(response, HttpStatus.OK);
+    public ResponseEntity<Long> patch(@PathVariable("user-id") @Positive Long userId,
+                                                  @Valid @RequestBody UserDto.Patch patchDto) {
+        patchDto.setUserId(userId);
+        Area area = areaService.findVerifiedAreaByAreaCode(patchDto.getAreaCode());
+        User user = userService.updateUser(patchDto, area);
+        return new ResponseEntity<>(user.getId(), HttpStatus.OK);
     }
 
     @GetMapping("/{user-id}")
-    public ResponseEntity<?> get(@PathVariable("user-id") @Positive long userId) {
-        UserDto.Response response = userService.getUser(userId);
+    public ResponseEntity<UserDto.Response> get(@PathVariable("user-id") @Positive Long userId) {
+        UserDto.Response response = userService.findUser(userId);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
     @DeleteMapping("/{user-id}")
-    public ResponseEntity<?> delete(@PathVariable("user-id") @Positive long userId) {
+    public ResponseEntity<Void> delete(@PathVariable("user-id") @Positive Long userId) {
         userService.deleteUser(userId);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }

--- a/server/src/main/java/jeju/oneroom/user/dto/UserDto.java
+++ b/server/src/main/java/jeju/oneroom/user/dto/UserDto.java
@@ -5,43 +5,47 @@ import lombok.*;
 public class UserDto {
 
     @Getter
-    @AllArgsConstructor
     @Builder
     @NoArgsConstructor
+    @AllArgsConstructor
     public static class Post {
-        private String email; // 이메일
-        private String nickname; // 닉네임
+        private String email;
+        private String nickname;
     }
 
     @Getter
-    @AllArgsConstructor
     @Builder
     @NoArgsConstructor
+    @AllArgsConstructor
     public static class Patch {
         private Long id;
-        private String nickname; // 닉네임
+        private String nickname;
         private Long areaCode; // 관심지역
+
+        public void setUserId(Long id) {
+            this.id = id;
+        }
     }
 
     @Getter
-    @AllArgsConstructor
     @Builder
     @NoArgsConstructor
+    @AllArgsConstructor
     public static class Response {
-        private Long id; // id
-        private String email; // 이메일
-        private String area;
-        private String nickname; //닉네임
-        private String profileImageUrl;
+        private Long id;
+        private String email;
+        private String areaName;
+        private String nickname;
+        private String profileImageUrl; // 프로필 이미지 URL
     }
 
     @Getter
-    @AllArgsConstructor
     @Builder
     @NoArgsConstructor
-    public static class SimpleResponseDto {
-        private Long id; // userId 보내기
-        private String nickname; //닉네임
-        private String profileImageUrl; // 프로필 이미지 URL
+    @AllArgsConstructor
+    public static class SimpleResponse {
+        private Long id;
+        private String nickname;
+        private String profileImageUrl;
     }
 }

--- a/server/src/main/java/jeju/oneroom/user/entity/User.java
+++ b/server/src/main/java/jeju/oneroom/user/entity/User.java
@@ -17,11 +17,15 @@ import java.util.List;
 public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "user_id", insertable = false, updatable = false)
+    @Column(name = "user_id")
     private Long id;
 
+    @Column(nullable = false)
     private String email;
+
+    @Column(nullable = false)
     private String nickname;
+
     private String profileImageUrl;
 
     @OneToMany(mappedBy = "sender")
@@ -46,6 +50,11 @@ public class User extends BaseEntity {
         this.area = area;
         this.reviews = reviews;
         this.id = id;
+    }
+
+    public void update(String nickname, Area area) {
+        this.nickname = nickname;
+        this.area = area;
     }
 
     public void setArea(Area area) {

--- a/server/src/main/java/jeju/oneroom/user/mapper/UserMapper.java
+++ b/server/src/main/java/jeju/oneroom/user/mapper/UserMapper.java
@@ -1,27 +1,16 @@
 package jeju.oneroom.user.mapper;
 
-import jeju.oneroom.area.entity.Area;
 import jeju.oneroom.user.dto.UserDto;
 import jeju.oneroom.user.entity.User;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.ReportingPolicy;
-
-import java.util.List;
+import org.mapstruct.*;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface UserMapper {
     User postDtoToUser(UserDto.Post postDto);
 
-    @Mapping(target = "area", ignore=true)
-    User patchDtoToUser(UserDto.Patch patchDto);
-
-    //@Mapping(target = "town", expression = "user.get")
+    @Mapping(target = "areaName", source = "area.areaName")
+    @Mapping(target = "profileImageUrl", ignore = true)
     UserDto.Response userToResponseDto(User user);
 
-    UserDto.SimpleResponseDto userToSimpleResponseDto(User user);
-
-    default String toString(Area area){
-        return area.getAreaName();
-    }
+    UserDto.SimpleResponse userToSimpleResponseDto(User user);
 }

--- a/server/src/main/java/jeju/oneroom/user/repository/UserRepository.java
+++ b/server/src/main/java/jeju/oneroom/user/repository/UserRepository.java
@@ -2,8 +2,6 @@ package jeju.oneroom.user.repository;
 
 import jeju.oneroom.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 }

--- a/server/src/main/java/jeju/oneroom/user/service/UserService.java
+++ b/server/src/main/java/jeju/oneroom/user/service/UserService.java
@@ -14,36 +14,33 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class UserService {
-    private final UserRepository userRepository;
+
     private final UserMapper userMapper;
-    private final AreaRepository areaRepository;
+    private final UserRepository userRepository;
 
-    //회원 생성
-    public UserDto.Response createUser(UserDto.Post postDto) {
-        User createUser = userRepository.save(userMapper.postDtoToUser(postDto));
-        return userMapper.userToResponseDto(createUser);
+    @Transactional
+    public User createUser(UserDto.Post postDto) {
+        return userRepository.save(userMapper.postDtoToUser(postDto));
     }
 
-    //회원 정보 수정
-    public UserDto.Response updateUser(UserDto.Patch patchDto) {
-        User findUser = userMapper.patchDtoToUser(patchDto);
-        Area area = areaRepository.findById(patchDto.getAreaCode()).orElse(null);
-        findUser.setArea(area);
-        return userMapper.userToResponseDto(findUser);
+    @Transactional
+    public User updateUser(UserDto.Patch patchDto, Area area) {
+        User foundUser = verifyExistsUser(patchDto.getId());
+        foundUser.update(patchDto.getNickname(), area);
+        return foundUser;
     }
 
-    //회원 단건 조회
-    public UserDto.Response getUser(long userId) {
-        return userMapper.userToResponseDto(userRepository.findById(userId).orElse(null));
+    public UserDto.Response findUser(Long userId) {
+        User foundUser = verifyExistsUser(userId);
+        return userMapper.userToResponseDto(foundUser);
     }
 
-    //회원 탈퇴
-    public void deleteUser(long userId) {
+    @Transactional
+    public void deleteUser(Long userId) {
         userRepository.deleteById(userId);
     }
 
-    // 유효한 회원 확인
-    public User findVerifiedUser(long userId) {
+    public User verifyExistsUser(Long userId) {
         return userRepository.findById(userId).orElseThrow(() -> new RuntimeException("USER_NOT_FOUND"));
     }
 }


### PR DESCRIPTION
## 개요
- [#68]

## 변경사항
- User Service 2차 구현
- UserDto의 UserResponseDto -> UserResponse로 수정
(MessageDto, PostDto, PostCommentDto, ReviewDto 변경)
- UserService의 findVerifiedUser 메서드명 -> verifyExistsUser로 수정
(ReviewController 변경)
- 추가, 수정 시 User의 id를 반환하도록 수정
- 기존 UserService에서 AreaRepository의 의존을 UserController에서 AreaService를 의존하도록 수정
- UserMapper 변경
